### PR TITLE
Initial development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
-*$py.class
 
 # C extensions
 *.so
@@ -9,12 +8,11 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+bin/
 build/
 develop-eggs/
 dist/
-downloads/
 eggs/
-.eggs/
 lib/
 lib64/
 parts/
@@ -24,12 +22,6 @@ var/
 .installed.cfg
 *.egg
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
@@ -38,25 +30,26 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
-.coverage.*
 .cache
 nosetests.xml
 coverage.xml
-*,cover
-.hypothesis/
+.noseids
+cover/
 
 # Translations
 *.mo
-*.pot
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Rope
+.ropeproject
 
 # Django stuff:
 *.log
+*.pot
 
 # Sphinx documentation
 docs/_build/
-
-# PyBuilder
-target/
-
-#Ipython Notebook
-.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # krux-troposphere
 
-Krux Python class built on top of `krux-boto` for interacting with `Troposphere` and `Cloud Formation`.
+Krux Python class built on top of `krux-boto` for interacting with [`Troposphere`](https://github.com/cloudtools/troposphere) and `Cloud Formation`.
 
 ## Warning
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# krux-troposphere
+
+Krux Python class built on top of `krux-boto` for interacting with `Troposphere` and `Cloud Formation`.
+
+## Warning
+
+In the current version, `krux_troposphere.troposphere.Troposphere` is only compatible with `krux_boto.boto.Boto3` object. Passing other objects, such as `krux_boto.boto.Boto`, will cause an exception.
+
+## Application quick start
+
+The most common use case is to build a CLI script using `krux_boto.cli.Application`.
+Here's how to do that:
+
+```python
+
+from krux_boto.cli import Application
+from krux_troposphere.troposphere import Troposphere
+
+def main():
+    # The name must be unique to the organization. The object
+    # returned inherits from krux.cli.Application, so it provides
+    # all that functionality as well.
+    app = Application(name='krux-my-boto-script')
+
+    troposphere = Troposphere(boto=app.boto3)
+
+    # Do magic with troposphere.template
+
+    troposphere.save()
+
+### Run the application stand alone
+if __name__ == '__main__':
+    main()
+
+```
+
+As long as you get an instance of `krux_boto.boto.Boto3`, the rest are the same. Refer to `krux_boto` module's [README](https://github.com/krux/python-krux-boto/blob/master/README.md) on various ways to instanciate the class.

--- a/krux_troposphere/cli.py
+++ b/krux_troposphere/cli.py
@@ -34,6 +34,9 @@ class Application(krux_boto.cli.Application):
         add_troposphere_cli_arguments(parser, include_boto_arguments=False)
 
     def run(self):
+        # GOTCHA: Purposely left blank. Troposphere does not provide a solid parser of the Cloud Formation template.
+        # This makes getter rather difficult. Without creating a test stack that is perfectly constant and lots of code to
+        # regenerate that stack, I cannot make a no-op call. So leaving this method empty for now.
         pass
 
 

--- a/krux_troposphere/cli.py
+++ b/krux_troposphere/cli.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import os
+
+#
+# Internal libraries
+#
+
+from krux.cli import get_group
+import krux_boto.cli
+from krux_troposphere.troposphere import add_troposphere_cli_arguments, get_troposphere, NAME
+
+
+class Application(krux_boto.cli.Application):
+
+    def __init__(self, name=NAME):
+        # Call to the superclass to bootstrap.
+        super(Application, self).__init__(name=name)
+
+        self.troposphere = get_troposphere(self.args, self.logger, self.stats)
+
+    def add_cli_arguments(self, parser):
+        # Call to the superclass
+        super(Application, self).add_cli_arguments(parser)
+
+        add_troposphere_cli_arguments(parser, include_boto_arguments=False)
+
+    def run(self):
+        pass
+
+
+def main():
+    app = Application()
+    with app.context():
+        app.run()
+
+
+# Run the application stand alone
+if __name__ == '__main__':
+    main()

--- a/krux_troposphere/troposphere.py
+++ b/krux_troposphere/troposphere.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+from abc import ABCMeta, abstractmethod
+import uuid
+
+#
+# Third party libraries
+#
+
+import simplejson
+
+#
+# Internal libraries
+#
+
+from krux.logging import get_logger
+from krux.stats import get_stats
+from krux.cli import get_parser, get_group
+from krux_boto.boto import Boto3, add_boto_cli_arguments
+
+
+NAME = 'krux-troposphere'
+
+
+def get_troposphere(args=None, logger=None, stats=None):
+    """
+    Return a usable Sqs object without creating a class around it.
+
+    In the context of a krux.cli (or similar) interface the 'args', 'logger'
+    and 'stats' objects should already be present. If you don't have them,
+    however, we'll attempt to provide usable ones for the SQS setup.
+
+    (If you omit the add_sqs_cli_arguments() call during other cli setup,
+    the Boto object will still work, but its cli options won't show up in
+    --help output)
+
+    (This also handles instantiating a Boto3 object on its own.)
+    """
+    if not args:
+        parser = get_parser()
+        add_troposphere_cli_arguments(parser)
+        args = parser.parse_args()
+
+    if not logger:
+        logger = get_logger(name=NAME)
+
+    if not stats:
+        stats = get_stats(prefix=NAME)
+
+    boto = Boto3(
+        log_level=args.boto_log_level,
+        access_key=args.boto_access_key,
+        secret_key=args.boto_secret_key,
+        region=args.boto_region,
+        logger=logger,
+        stats=stats,
+    )
+    return Troposphere(
+        boto=boto,
+        logger=logger,
+        stats=stats,
+    )
+
+
+def add_troposphere_cli_arguments(parser, include_boto_arguments=True):
+    """
+    Utility function for adding SQS specific CLI arguments.
+    """
+    if include_boto_arguments:
+        # GOTCHA: Since many modules use krux_boto, the krux_boto's CLI arguments can be included twice,
+        # causing an error. This creates a way to circumvent that.
+
+        # Add all the boto arguments
+        add_boto_cli_arguments(parser)
+
+    # Add those specific to the application
+    group = get_group(parser, NAME)
+
+
+class Troposphere(object):
+    """
+    A manager to handle all SQS related functions.
+    Each instance is locked to a connection to a designated region (self.boto.cli_region).
+    """
+
+    def __init__(
+        self,
+        boto,
+        logger=None,
+        stats=None,
+    ):
+        # Private variables, not to be used outside this module
+        self._name = NAME
+        self._logger = logger or get_logger(self._name)
+        self._stats = stats or get_stats(prefix=self._name)
+
+        if not isinstance(boto, Boto3):
+            raise NotImplementedError('Currently krux_troposphere.troposphere.Troposphere only supports krux_boto.boto.Boto3')
+
+        #self._resource = boto.resource('sqs')
+        self._queues = {}

--- a/krux_troposphere/troposphere.py
+++ b/krux_troposphere/troposphere.py
@@ -101,6 +101,11 @@ class Troposphere(object):
         logger=None,
         stats=None,
     ):
+        """
+        :param boto: :py:class:`krux_boto.boto.Boto3` Boto3 object used to connect to Cloud Formation
+        :param logger: :py:class:`logging.Logger` Logger, recommended to be obtained using krux.cli.Application
+        :param stats: :py:class:`kruxstatsd.StatsClient` Stats, recommended to be obtained using krux.cli.Application
+        """
         # Private variables, not to be used outside this module
         self._name = NAME
         self._logger = logger or get_logger(self._name)
@@ -113,6 +118,15 @@ class Troposphere(object):
         self.template = troposphere.Template()
 
     def _is_stack_exists(self, stack_name):
+        """
+        Check if the given Cloud Formation stack exists
+
+        GOTCHA: There is no simple way to check the existence of a stack.
+        The template for the stack is fetched and if an expected exception occur (Unable to find stack),
+        then the stack is deemed not existing.
+
+        :param stack_name: :py:class:`str` Name of the stack to check
+        """
         try:
             # See if we can get a template for this
             self._cf.get_template(StackName=stack_name)
@@ -127,6 +141,14 @@ class Troposphere(object):
             raise
 
     def save(self, stack_name):
+        """
+        Saves the template to the given Cloud Formation stack.
+
+        The method internally checks whether the stack exists and either creates or updates the stack
+        with the template in this object.
+
+        :param stack_name: :py:class:`str` Name of the stack to check
+        """
         if self._is_stack_exists(stack_name):
             try:
                 self._cf.update_stack(

--- a/requirements.pip
+++ b/requirements.pip
@@ -3,6 +3,7 @@
 
 # Krux-boto library which this is built on
 krux-boto==1.0.3
+krux-s3==0.0.1
 
 ### Library to create cloudformation templates
 ### Version is latest at time of writing

--- a/requirements.pip
+++ b/requirements.pip
@@ -4,6 +4,11 @@
 # Krux-boto library which this is built on
 krux-boto==1.0.3
 
+### Library to create cloudformation templates
+### Version is latest at time of writing
+# https://github.com/cloudtools/troposphere/tree/1.5.0
+troposphere==1.5.0
+
 # Transitive libraries
 # This is needed so there are no version conflicts when
 # one downstream library does NOT specify the version it wants,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+description-file = README.md
+
+[nosetests]
+cover-branches = 1
+cover-html = 1
+cover-inclusive = 1
+cover-package = krux_troposphere
+verbosity = 2
+with-coverage = 1
+with-id = 1

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
+            'krux-troposphere-test = krux_troposphere.cli:main',
         ],
     },
     test_suite='test',

--- a/test/troposphere_test.py
+++ b/test/troposphere_test.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+#
+# © 2016 Krux Digital, Inc.
+#
+
+#
+# Standard libraries
+#
+
+from __future__ import absolute_import
+import unittest
+
+#
+# Third party libraries
+#
+
+from mock import MagicMock, patch
+
+#
+# Internal libraries
+#
+
+import krux_boto.boto
+import krux_troposphere.troposphere
+
+
+class TroposphereTest(unittest.TestCase):
+    TEST_REGION = 'us-west-2'
+    TEST_QUEUE_NAME = 'jib-test'
+
+    def setUp(self):
+        self._cf = MagicMock()
+        boto = MagicMock(
+            client=MagicMock(
+                return_value=self._cf
+            )
+        )
+
+        with patch('krux_troposphere.troposphere.isinstance', MagicMock(return_value=True)):
+            self._troposphere = krux_troposphere.troposphere.Troposphere(
+                boto=boto
+            )
+
+    def test_is_stack_exists(self):
+        pass

--- a/test/troposphere_test.py
+++ b/test/troposphere_test.py
@@ -44,6 +44,7 @@ class TroposphereTest(unittest.TestCase):
     NO_UPDATE_ERROR_MSG = 'No updates are to be performed.'
 
     def setUp(self):
+        # Set up a fake Boto3 object
         self._cf = MagicMock()
         boto = MagicMock(
             client=MagicMock(
@@ -51,18 +52,25 @@ class TroposphereTest(unittest.TestCase):
             )
         )
 
+        # Mock isinstance() so that it will accept MagicMock object
         with patch('krux_troposphere.troposphere.isinstance', MagicMock(return_value=True)):
             self._troposphere = krux_troposphere.troposphere.Troposphere(
                 boto=boto
             )
 
     def test_is_stack_exists_success(self):
+        """
+        _is_stack_exists() handles existing stacks properly
+        """
         self._cf.get_template.return_value = True
 
         self.assertTrue(self._troposphere._is_stack_exists(self.TEST_STACK_NAME))
         self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
 
     def test_is_stack_exists_failure(self):
+        """
+        _is_stack_exists() handles non-existing stacks properly
+        """
         resp = deepcopy(self.FAKE_ERROR_RESP)
         resp['Error']['Message'] = self.STACK_NOT_EXIST_ERROR_MSG
         self._cf.get_template.side_effect = ClientError(resp, '')
@@ -71,6 +79,9 @@ class TroposphereTest(unittest.TestCase):
         self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
 
     def test_is_stack_exists_boto_error(self):
+        """
+        _is_stack_exists() handles unknown boto errors properly
+        """
         resp = deepcopy(self.FAKE_ERROR_RESP)
         resp['Error']['Message'] = 'An error that I cannot handle happened'
         self._cf.get_template.side_effect = ClientError(resp, '')
@@ -80,6 +91,9 @@ class TroposphereTest(unittest.TestCase):
             self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
 
     def test_is_stack_exists_std_error(self):
+        """
+        _is_stack_exists() handles unknown standard errors properly
+        """
         self._cf.get_template.side_effect = StandardError()
 
         with self.assertRaises(StandardError):
@@ -87,6 +101,9 @@ class TroposphereTest(unittest.TestCase):
             self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
 
     def test_save_create(self):
+        """
+        save() detects a new stack and creates it properly
+        """
         self._cf.create_stack.return_value = True
 
         with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=False)):
@@ -97,6 +114,9 @@ class TroposphereTest(unittest.TestCase):
             )
 
     def test_save_update_success(self):
+        """
+        save() detects an existing stack and updates it properly
+        """
         self._cf.update_stack.return_value = True
 
         with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):
@@ -107,6 +127,9 @@ class TroposphereTest(unittest.TestCase):
             )
 
     def test_save_update_no_update(self):
+        """
+        save() detects when there is no change in the update and does not propagate the error
+        """
         resp = deepcopy(self.FAKE_ERROR_RESP)
         resp['Error']['Message'] = self.NO_UPDATE_ERROR_MSG
         self._cf.update_stack.side_effect = ClientError(resp, '')
@@ -119,6 +142,9 @@ class TroposphereTest(unittest.TestCase):
             )
 
     def test_save_update_boto_error(self):
+        """
+        save() handles unknown boto errors properly
+        """
         resp = deepcopy(self.FAKE_ERROR_RESP)
         resp['Error']['Message'] = 'An error that I cannot handle happened'
         self._cf.update_stack.side_effect = ClientError(resp, '')
@@ -132,6 +158,9 @@ class TroposphereTest(unittest.TestCase):
                 )
 
     def test_save_update_std_error(self):
+        """
+        save() handles unknown standard errors properly
+        """
         self._cf.update_stack.side_effect = StandardError()
 
         with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):

--- a/test/troposphere_test.py
+++ b/test/troposphere_test.py
@@ -8,13 +8,16 @@
 #
 
 from __future__ import absolute_import
+from copy import deepcopy
 import unittest
 
 #
 # Third party libraries
 #
 
+import simplejson
 from mock import MagicMock, patch
+from botocore.exceptions import ClientError
 
 #
 # Internal libraries
@@ -25,8 +28,20 @@ import krux_troposphere.troposphere
 
 
 class TroposphereTest(unittest.TestCase):
-    TEST_REGION = 'us-west-2'
-    TEST_QUEUE_NAME = 'jib-test'
+    TEST_STACK_NAME = 'test_stack'
+    FAKE_ERROR_RESP = {
+        'ResponseMetadata': {
+            'HTTPStatusCode': 400,
+            'RequestId': 'fake-request',
+        },
+        'Error': {
+            'Message': '',
+            'Code': 'ValidationError',
+            'Type': 'Sender',
+        }
+    }
+    STACK_NOT_EXIST_ERROR_MSG = 'Stack with id {stack_name} does not exist'.format(stack_name=TEST_STACK_NAME)
+    NO_UPDATE_ERROR_MSG = 'No updates are to be performed.'
 
     def setUp(self):
         self._cf = MagicMock()
@@ -41,5 +56,88 @@ class TroposphereTest(unittest.TestCase):
                 boto=boto
             )
 
-    def test_is_stack_exists(self):
-        pass
+    def test_is_stack_exists_success(self):
+        self._cf.get_template.return_value = True
+
+        self.assertTrue(self._troposphere._is_stack_exists(self.TEST_STACK_NAME))
+        self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
+
+    def test_is_stack_exists_failure(self):
+        resp = deepcopy(self.FAKE_ERROR_RESP)
+        resp['Error']['Message'] = self.STACK_NOT_EXIST_ERROR_MSG
+        self._cf.get_template.side_effect = ClientError(resp, '')
+
+        self.assertFalse(self._troposphere._is_stack_exists(self.TEST_STACK_NAME))
+        self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
+
+    def test_is_stack_exists_boto_error(self):
+        resp = deepcopy(self.FAKE_ERROR_RESP)
+        resp['Error']['Message'] = 'An error that I cannot handle happened'
+        self._cf.get_template.side_effect = ClientError(resp, '')
+
+        with self.assertRaises(ClientError):
+            self._troposphere._is_stack_exists(self.TEST_STACK_NAME)
+            self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
+
+    def test_is_stack_exists_std_error(self):
+        self._cf.get_template.side_effect = StandardError()
+
+        with self.assertRaises(StandardError):
+            self._troposphere._is_stack_exists(self.TEST_STACK_NAME)
+            self._cf.get_template.assert_called_once_with(StackName=self.TEST_STACK_NAME)
+
+    def test_save_create(self):
+        self._cf.create_stack.return_value = True
+
+        with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=False)):
+            self._troposphere.save(self.TEST_STACK_NAME)
+            self._cf.create_stack.assert_called_once_with(
+                StackName=self.TEST_STACK_NAME,
+                TemplateBody=self._troposphere.template.to_json()
+            )
+
+    def test_save_update_success(self):
+        self._cf.update_stack.return_value = True
+
+        with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):
+            self._troposphere.save(self.TEST_STACK_NAME)
+            self._cf.update_stack.assert_called_once_with(
+                StackName=self.TEST_STACK_NAME,
+                TemplateBody=self._troposphere.template.to_json()
+            )
+
+    def test_save_update_no_update(self):
+        resp = deepcopy(self.FAKE_ERROR_RESP)
+        resp['Error']['Message'] = self.NO_UPDATE_ERROR_MSG
+        self._cf.update_stack.side_effect = ClientError(resp, '')
+
+        with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):
+            self._troposphere.save(self.TEST_STACK_NAME)
+            self._cf.update_stack.assert_called_once_with(
+                StackName=self.TEST_STACK_NAME,
+                TemplateBody=self._troposphere.template.to_json()
+            )
+
+    def test_save_update_boto_error(self):
+        resp = deepcopy(self.FAKE_ERROR_RESP)
+        resp['Error']['Message'] = 'An error that I cannot handle happened'
+        self._cf.update_stack.side_effect = ClientError(resp, '')
+
+        with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):
+            with self.assertRaises(ClientError):
+                self._troposphere.save(self.TEST_STACK_NAME)
+                self._cf.update_stack.assert_called_once_with(
+                    StackName=self.TEST_STACK_NAME,
+                    TemplateBody=self._troposphere.template.to_json()
+                )
+
+    def test_save_update_std_error(self):
+        self._cf.update_stack.side_effect = StandardError()
+
+        with patch('krux_troposphere.troposphere.Troposphere._is_stack_exists', MagicMock(return_value=True)):
+            with self.assertRaises(StandardError):
+                self._troposphere.save(self.TEST_STACK_NAME)
+                self._cf.update_stack.assert_called_once_with(
+                    StackName=self.TEST_STACK_NAME,
+                    TemplateBody=self._troposphere.template.to_json()
+                )


### PR DESCRIPTION
1. Basic implementation of `krux-troposphere`. It contains a public facing Troposphere template and a private Cloud Formation client. The users are expected to make changes to the Troposphere template and call `save()` method.
2. Basic CLI application containing `krux-troposphere` object. Following the pattern of all `krux-boto` related libraries.
3. Unit tests for all `krux-troposphere` methods. This is necessary because it is difficult to test this library without creating lots of changes in AWS.
