### PR TITLE
Allow users to set specific S3 bucket

### DIFF
--- a/krux_cloud_formation/cli.py
+++ b/krux_cloud_formation/cli.py
@@ -27,11 +27,15 @@ class Application(krux_s3.cli.Application):
 
         self.cloud_formation = get_cloud_formation(self.args, self.logger, self.stats)
 
-    def add_cli_arguments(self, parser):
+    def add_cli_arguments(self, parser, include_bucket_arguments=True):
         # Call to the superclass
         super(Application, self).add_cli_arguments(parser)
 
-        add_cloud_formation_cli_arguments(parser, include_boto_arguments=False)
+        add_cloud_formation_cli_arguments(
+            parser=parser,
+            include_boto_arguments=False,
+            include_bucket_arguments=include_bucket_arguments
+        )
 
     def run(self):
         # GOTCHA: Purposely left blank. Troposphere does not provide a solid parser of the Cloud Formation template.

--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -72,7 +72,7 @@ def get_cloud_formation(args=None, logger=None, stats=None):
         secret_key=args.boto_secret_key,
         # This boto is for S3 upload and is using a constant region,
         # matching the TEMP_S3_BUCKET
-        region=args.bucket_region,
+        region=getattr(args, 'bucket_region', CloudFormation.DEFAULT_S3_REGION),
         logger=logger,
         stats=stats,
     )
@@ -81,16 +81,17 @@ def get_cloud_formation(args=None, logger=None, stats=None):
         logger=logger,
         stats=stats,
     )
+
     return CloudFormation(
         boto=boto3,
         s3=s3,
-        bucket_name=args.bucket_name,
+        bucket_name=getattr(args, 'bucket_name', CloudFormation.DEFAULT_S3_BUCKET),
         logger=logger,
         stats=stats,
     )
 
 
-def add_cloud_formation_cli_arguments(parser, include_boto_arguments=True):
+def add_cloud_formation_cli_arguments(parser, include_boto_arguments=True, include_bucket_arguments=True):
     """
     Utility function for adding CloudFormation specific CLI arguments.
     """
@@ -106,19 +107,21 @@ def add_cloud_formation_cli_arguments(parser, include_boto_arguments=True):
     # Add those specific to the application
     group = get_group(parser, NAME)
 
-    group.add_argument(
-        '--bucket-name',
-        type=str,
-        default=CloudFormation.DEFAULT_S3_BUCKET,
-        help='Name of the bucket to upload cloud formation template to (Default: %(default)s)'
-    )
+    if include_bucket_arguments:
+        # If you want to fix the S3 bucket used to upload templates, do not use these arguments
+        group.add_argument(
+            '--bucket-name',
+            type=str,
+            default=CloudFormation.DEFAULT_S3_BUCKET,
+            help='Name of the bucket to upload cloud formation template to (Default: %(default)s)'
+        )
 
-    group.add_argument(
-        '--bucket-region',
-        type=str,
-        default=CloudFormation.DEFAULT_S3_REGION,
-        help='Region of the bucket to upload cloud formation template to (Default: %(default)s)'
-    )
+        group.add_argument(
+            '--bucket-region',
+            type=str,
+            default=CloudFormation.DEFAULT_S3_REGION,
+            help='Region of the bucket to upload cloud formation template to (Default: %(default)s)'
+        )
 
 
 class CloudFormation(object):

--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -31,8 +31,6 @@ from krux_s3.s3 import S3, add_s3_cli_arguments
 
 
 NAME = 'krux-cloud-formation'
-TEMP_S3_BUCKET = 'krux-temp'
-TEMP_S3_REGION = 'us-east-1'
 
 
 def get_cloud_formation(args=None, logger=None, stats=None):
@@ -74,7 +72,7 @@ def get_cloud_formation(args=None, logger=None, stats=None):
         secret_key=args.boto_secret_key,
         # This boto is for S3 upload and is using a constant region,
         # matching the TEMP_S3_BUCKET
-        region=TEMP_S3_REGION,
+        region=args.bucket_region,
         logger=logger,
         stats=stats,
     )
@@ -86,6 +84,7 @@ def get_cloud_formation(args=None, logger=None, stats=None):
     return CloudFormation(
         boto=boto3,
         s3=s3,
+        bucket_name=args.bucket_name,
         logger=logger,
         stats=stats,
     )
@@ -107,6 +106,20 @@ def add_cloud_formation_cli_arguments(parser, include_boto_arguments=True):
     # Add those specific to the application
     group = get_group(parser, NAME)
 
+    group.add_argument(
+        '--bucket-name',
+        type=str,
+        default=CloudFormation.DEFAULT_S3_BUCKET,
+        help='Name of the bucket to upload cloud formation template to (Default: %(default)s)'
+    )
+
+    group.add_argument(
+        '--bucket-region',
+        type=str,
+        default=CloudFormation.DEFAULT_S3_REGION,
+        help='Region of the bucket to upload cloud formation template to (Default: %(default)s)'
+    )
+
 
 class CloudFormation(object):
     """
@@ -116,6 +129,9 @@ class CloudFormation(object):
 
     STACK_NOT_EXIST_ERROR_MSG = 'Stack with id {stack_name} does not exist'
     NO_UPDATE_ERROR_MSG = 'No updates are to be performed.'
+    DEFAULT_S3_BUCKET = 'krux-temp'
+    DEFAULT_S3_REGION = 'us-east-1'
+
     _S3_KEY_TEMPLATE = '{name}/{stack_name}-{datestamp}'
     _DATESTAMP_TEMPLATE = '{year}{month}{date}-{hour}{minute}{second}'
     # S3 link expires after an hour
@@ -125,6 +141,7 @@ class CloudFormation(object):
         self,
         boto,
         s3,
+        bucket_name=DEFAULT_S3_BUCKET,
         logger=None,
         stats=None,
     ):
@@ -142,6 +159,7 @@ class CloudFormation(object):
             raise NotImplementedError('Currently krux_cloud_formation.cloud_formation.CloudFormation only supports krux_boto.boto.Boto3')
 
         self._s3 = s3
+        self._bucket_name = bucket_name
 
         self._cf = boto.client('cloudformation')
         self.template = troposphere.Template()
@@ -194,7 +212,7 @@ class CloudFormation(object):
             stack_name=stack_name,
             datestamp=CloudFormation._get_timestamp(datetime.utcnow()),
         )
-        s3_file = self._s3.create_key(bucket_name=TEMP_S3_BUCKET, key=key, str_content=self.template.to_json())
+        s3_file = self._s3.create_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
 
         if self._is_stack_exists(stack_name):
             try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.0.1'
+VERSION = '0.1.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-cloud-formation'


### PR DESCRIPTION
1. Exposes the fact that templates are uploaded to an S3 file before being applied to a Cloud Formation.
2. Allow users to specify the S3 bucket to be used and file name for each template.
3. Corresponding unit test changes.
