### PR TITLE
Use the same S3 file to store templates

### DIFF
--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -200,10 +200,11 @@ class CloudFormation(object):
         :param s3_key: :py:class:`str` Name of the s3 file to be used to upload the template. If set to None, stack_name is used.
         """
         key = s3_key or stack_name
-        s3_file = self._s3.create_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
 
         if self._is_stack_exists(stack_name):
             try:
+                s3_file = self._s3.update_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
+
                 self._cf.update_stack(
                     StackName=stack_name,
                     TemplateURL=s3_file.generate_url(self._S3_URL_EXPIRY)
@@ -216,6 +217,8 @@ class CloudFormation(object):
                 # Unknown error. Raise again.
                 raise
         else:
+            s3_file = self._s3.create_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
+
             self._cf.create_stack(
                 StackName=stack_name,
                 TemplateURL=s3_file.generate_url(self._S3_URL_EXPIRY)

--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -202,9 +202,9 @@ class CloudFormation(object):
         key = s3_key or stack_name
 
         if self._is_stack_exists(stack_name):
-            try:
-                s3_file = self._s3.update_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
+            s3_file = self._s3.update_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
 
+            try:
                 self._cf.update_stack(
                     StackName=stack_name,
                     TemplateURL=s3_file.generate_url(self._S3_URL_EXPIRY)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-cloud-formation'

--- a/test/cloud_formation_test.py
+++ b/test/cloud_formation_test.py
@@ -68,6 +68,9 @@ class TroposphereTest(unittest.TestCase):
         self._s3 = MagicMock(
             create_key=MagicMock(
                 return_value=s3_file
+            ),
+            update_key=MagicMock(
+                return_value=s3_file
             )
         )
 
@@ -211,7 +214,7 @@ class TroposphereTest(unittest.TestCase):
 
         with patch('krux_cloud_formation.cloud_formation.CloudFormation._is_stack_exists', MagicMock(return_value=True)):
             self._cfn.save(self.TEST_STACK_NAME)
-            self._s3.create_key.assert_called_once_with(
+            self._s3.update_key.assert_called_once_with(
                 bucket_name=self.S3_BUCKET,
                 key=self.TEST_STACK_NAME,
                 str_content=self._cfn.template.to_json()


### PR DESCRIPTION
#### What's this PR do?

This PR changes the S3 storage so that the same S3 file is used for a given cloud formation template.
#### How was this PR manually tested?

The change was manually tested on development environment.
#### Any background context you want to provide?

This is so that the S3 file can be versioned and logged to see who made what changes when.
