### PR TITLE
Delete cloud formation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,37 @@
+## What does this PR do?
+
+_Describe the effects of your pull request in detail. If multiple
+changes are involved, a bulleted list is often useful._
+
+## Why is this change being made?
+
+_Describe the reasoning and background context for your
+change. Include a link to relevant ticket(s)._
+
+## Where should the reviewer start?
+
+_Give the reviewer a good entry point and/or path through your change
+set which will enable them to understand the logic of the change._
+
+## How was this tested? How can the reviewer verify your testing?
+
+_Describe the steps you used to test your change. Provide evidence of
+testing or explicit, repeatable instructions the reviewer can follow
+to verify your testing._
+
+## What gif best describes this PR or how it makes you feel?
+
+_Insert an appropriate gif/meme to brighten up your reviewer's day._
+
+## Completion checklist
+
+- [ ] The pull request has been appropriately labelled according to
+  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
+- [ ] The change has unit & integration tests as appropriate.
+- [ ] Documentation has been updated.
+- [ ] Dependencies have been documented, deployed, and verified as
+      appropriate.
+- [ ] Stakeholders have been notified. Workflow-impacting changes have
+      been appropriately socialized to avoid surprises.
+- [ ] Large or high-impact changes have been canaried in the
+      appropriate environment(s).

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ cover/
 
 # Sphinx documentation
 docs/_build/
+
+# JetBrain IDE settings
+.idea/

--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -199,7 +199,7 @@ class CloudFormation(object):
         :param stack_name: :py:class:`str` Name of the stack to check
         :param s3_key: :py:class:`str` Name of the s3 file to be used to upload the template. If set to None, stack_name is used.
         """
-        key = s3_key or stack_name
+        key = s3_key if s3_key is not None else stack_name
 
         if self._is_stack_exists(stack_name):
             s3_file = self._s3.update_key(bucket_name=self._bucket_name, key=key, str_content=self.template.to_json())
@@ -223,3 +223,14 @@ class CloudFormation(object):
                 StackName=stack_name,
                 TemplateURL=s3_file.generate_url(self._S3_URL_EXPIRY)
             )
+
+    def delete(self, stack_name, s3_key=None):
+        """
+        Deletes the given Cloud Formation stack.
+
+        :param stack_name: :py:class:`str` Name of the stack to delete
+        :param s3_key: :py:class:`str` Name of the s3 file used to update the template. If set to None, stack_name is used.
+        """
+        key = s3_key if s3_key is not None else stack_name
+        self._s3.remove_keys(bucket_name=self._bucket_name, keys=[key])
+        self._cf.delete_stack(StackName=stack_name)

--- a/test/cloud_formation_test.py
+++ b/test/cloud_formation_test.py
@@ -274,3 +274,29 @@ class TroposphereTest(unittest.TestCase):
                     StackName=self.TEST_STACK_NAME,
                     TemplateURL=self.FAKE_URL
                 )
+
+    def test_delete(self):
+        """
+        delete() deletes a stack whether or not it exists
+        """
+        self._cfn.delete(self.TEST_STACK_NAME)
+        self._s3.remove_keys.assert_called_once_with(
+            bucket_name=self.S3_BUCKET,
+            keys=[self.TEST_STACK_NAME],
+        )
+        self._cf.delete_stack.assert_called_once_with(
+            StackName=self.TEST_STACK_NAME,
+        )
+
+    def test_delete_with_key(self):
+        """
+        delete() uses the given string as S3 file name correctly
+        """
+        self._cfn.delete(self.TEST_STACK_NAME, self.S3_FAKE_KEY)
+        self._s3.remove_keys.assert_called_once_with(
+            bucket_name=self.S3_BUCKET,
+            keys=[self.S3_FAKE_KEY],
+        )
+        self._cf.delete_stack.assert_called_once_with(
+            StackName=self.TEST_STACK_NAME,
+        )


### PR DESCRIPTION
## What does this PR do?

This PR adds a delete functionality.
## Why is this change being made?

I want to create a way to delete a cloud formation for `krux-autoscale`.
## Where should the reviewer start?

`krux_cloud_formation/cloud_formation.py`
## How was this tested? How can the reviewer verify your testing?

The change was manually tested on development environment via unit tests.
## Completion checklist
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation has been updated.
