### PR TITLE
PE-2585: Fix get_cloud_formation()

### DIFF
--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -152,9 +152,12 @@ class CloudFormation(object):
         stats=None,
     ):
         """
-        :param boto: :py:class:`krux_boto.boto.Boto3` Boto3 object used to connect to Cloud Formation
-        :param logger: :py:class:`logging.Logger` Logger, recommended to be obtained using krux.cli.Application
-        :param stats: :py:class:`kruxstatsd.StatsClient` Stats, recommended to be obtained using krux.cli.Application
+        :param boto: Boto3 object used to connect to Cloud Formation
+        :type boto: krux_boto.boto.Boto3
+        :param logger: Logger, recommended to be obtained using krux.cli.Application
+        :type logger: logging.Logger
+        :param stats: Stats, recommended to be obtained using krux.cli.Application
+        :type stats: kruxstatsd.StatsClient
         """
         # Private variables, not to be used outside this module
         self._name = NAME
@@ -162,7 +165,10 @@ class CloudFormation(object):
         self._stats = stats or get_stats(prefix=self._name)
 
         if not isinstance(boto, Boto3):
-            raise NotImplementedError('Currently krux_cloud_formation.cloud_formation.CloudFormation only supports krux_boto.boto.Boto3')
+            raise NotImplementedError(
+                'Currently krux_cloud_formation.cloud_formation.CloudFormation '
+                'only supports krux_boto.boto.Boto3'
+            )
 
         self._s3 = s3
         self._bucket_name = bucket_name
@@ -178,7 +184,8 @@ class CloudFormation(object):
         The template for the stack is fetched and if an expected exception occur (Unable to find stack),
         then the stack is deemed not existing.
 
-        :param stack_name: :py:class:`str` Name of the stack to check
+        :param stack_name: Name of the stack to check
+        :type stack_name: str
         """
         try:
             # See if we can get a template for this
@@ -186,7 +193,8 @@ class CloudFormation(object):
             # The template was successfully retrieved; the stack exists
             return True
         except botocore.exceptions.ClientError as err:
-            if self._STACK_NOT_EXIST_ERROR_MSG.format(stack_name=stack_name) == err.response.get('Error', {}).get('Message', ''):
+            if (self._STACK_NOT_EXIST_ERROR_MSG.format(stack_name=stack_name) ==
+               err.response.get('Error', {}).get('Message', '')):
                 # The template was not retrieved; the stack does not exists
                 return False
 
@@ -200,8 +208,10 @@ class CloudFormation(object):
         The method internally checks whether the stack exists and either creates or updates the stack
         with the template in this object.
 
-        :param stack_name: :py:class:`str` Name of the stack to check
-        :param s3_key: :py:class:`str` Name of the s3 file to be used to upload the template. If set to None, stack_name is used.
+        :param stack_name: Name of the stack to check
+        :type stack_name: str
+        :param s3_key: Name of the s3 file to be used to upload the template. If set to None, stack_name is used.
+        :type s3_key: str
         """
         key = s3_key if s3_key is not None else stack_name
 
@@ -232,8 +242,10 @@ class CloudFormation(object):
         """
         Deletes the given Cloud Formation stack.
 
-        :param stack_name: :py:class:`str` Name of the stack to delete
-        :param s3_key: :py:class:`str` Name of the s3 file used to update the template. If set to None, stack_name is used.
+        :param stack_name: Name of the stack to delete
+        :type stack_name: str
+        :param s3_key: Name of the s3 file used to update the template. If set to None, stack_name is used.
+        :type s3_key: str
         """
         key = s3_key if s3_key is not None else stack_name
         self._s3.remove_keys(bucket_name=self._bucket_name, keys=[key])

--- a/krux_cloud_formation/cloud_formation.py
+++ b/krux_cloud_formation/cloud_formation.py
@@ -50,7 +50,11 @@ def get_cloud_formation(args=None, logger=None, stats=None):
     if not args:
         parser = get_parser()
         add_cloud_formation_cli_arguments(parser)
-        args = parser.parse_args()
+        # Parse only the known arguments added by add_cloud_formation_cli_arguments().
+        # We only need those arguments to create CloudFormation object, nothing else.
+        # parse_known_args() return (Namespace, list of unknown arguments),
+        # we only care about the Namespace object here.
+        args = parser.parse_known_args()[0]
 
     if not logger:
         logger = get_logger(name=NAME)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-cloud-formation'


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug that flags all extra CLI arguments as invalid if `self.args` is not passed to `get_cloud_formation()` function.

## Why is this change being made?
This is a bug in `get_cloud_formation()`. You should be able to pass nothing into these methods and get the same result.

## How was this tested? How can the reviewer verify your testing?
The changes are tested manually in the development environment by adding a test argument in `krux_cloud_formation.cli.Application`. A unit test for this bug has been added.

## Where should the reviewer start?
`krux_cloud_formation.cloud_formation.get_cloud_formation()`

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.